### PR TITLE
Add list interviews today method

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -138,6 +138,36 @@ public class TimeParser {
                 res.add(currentInterview);
             }
         }
+        System.out.println(res);
+        return res;
+    }
+
+    /**
+     * Lists out all interviews that have a start time of today
+     *
+     * @author Tan Kerway
+     * @param interviews the list of interviews that the user has
+     * @return a list of interviews whose start time is today, as given by LocalDateTime.now()
+     */
+    public static List<Interview> listInterviewsToday(UniqueInterviewList interviews) {
+        // get today's day, month, and year for checking
+        LocalDateTime today = LocalDateTime.now();
+        int todayDay = today.getDayOfMonth();
+        int todayMonth = today.getMonthValue();
+        int todayYear = today.getYear();
+        List<Interview> res = new ArrayList<>();
+        // loop over all the interviews, and add those that have today as the start time
+        for (Interview interview : interviews) {
+            LocalDateTime currentInterviewStartTime = interview.getInterviewStartTime();
+            int currentInterviewDay = currentInterviewStartTime.getDayOfMonth();
+            int currentInterviewMonth = currentInterviewStartTime.getMonthValue();
+            int currentInterviewYear = currentInterviewStartTime.getYear();
+            if (currentInterviewDay == todayDay
+                    && currentInterviewMonth == todayMonth
+                    && currentInterviewYear == todayYear) {
+                res.add(interview); // add the current interview if its start date is today
+            }
+        }
         return res;
     }
 

--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import seedu.address.model.interview.Interview;
@@ -244,6 +245,21 @@ public class TimeParser {
     }
 
     /**
+     * Sorts the list of interviews in ascending chronological order.
+     *
+     * @author Tan Kerway
+     *
+     */
+    public static List<Interview> sortInterviewsInChronologicalAscendingOrder(UniqueInterviewList interviews) {
+        List<Interview> res = new ArrayList<>();
+        for (Interview interview : interviews) {
+            res.add(interview);
+        }
+        res.sort(Comparator.comparing(Interview::getInterviewStartTime));
+        return res;
+    }
+
+    /**
      * Formats the time String.
      *
      * @author Tan Kerway
@@ -252,7 +268,6 @@ public class TimeParser {
      */
     public static String formatDate(LocalDateTime time) {
         assert time != null : "time should be not null";
-        // TODO FIX THIS; NEED TO FORMAT INTO AN ACCEPTABLE DATE
         return time.format(DateTimeFormatter.ofPattern("d/M/yy HHmm"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -5,16 +5,24 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.interview.Interview;
+import seedu.address.model.interview.UniqueInterviewList;
+import seedu.address.testutil.TypicalApplicants;
+import seedu.address.testutil.TypicalInterviews;
 
 class TimeParserTest {
     private static final LocalDateTime DEFAULT_DATE =
             LocalDateTime.of(1970, 1, 1, 0, 0);
 
-    // TESTS FOR THE TIMEPARSER STATIC FIELDS
+    /*
+     * Tests for the timeParser class
+     */
     @Test
     void testTimeParserDefaultDate() {
         assertEquals(DEFAULT_DATE, TimeParser.DEFAULT_DATE);
@@ -283,5 +291,260 @@ class TimeParserTest {
             hasError = true;
         }
         assertTrue(hasError);
+    }
+
+    /*
+     * Tests for the listInterviewClashes class
+     */
+    @Test
+    void testListInterviewClashesListFirstElement() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2024, 12, 21, 20, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 20, 30);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListFirstElement2() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2024, 12, 21, 18, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 22, 0);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListFirstElement3() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2024, 12, 21, 18, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 19, 1);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListFirstElement4() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2024, 12, 21, 20, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 22, 0);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListTwoClashes() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2024, 7, 12, 9, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 22, 0);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListThreeClashes() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2024, 5, 12, 9, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 22, 0);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListThreeClashes2() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2023, 5, 12, 9, 0);
+        LocalDateTime endTime = LocalDateTime.of(2025, 12, 21, 14, 0);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListFourClashes() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2023, 5, 12, 9, 0);
+        LocalDateTime endTime = LocalDateTime.of(2025, 12, 21, 22, 0);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_2);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewClashesListNoClashes() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime startTime = LocalDateTime.of(2023, 5, 12, 9, 0);
+        LocalDateTime endTime = LocalDateTime.of(2023, 12, 21, 22, 0);
+        List<Interview> expected = new ArrayList<>();
+        List<Interview> actual = TimeParser.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    /*
+     * Tests for the listsInterviewsToday class
+     */
+    @Test
+    void testListInterviewsToday() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewsToday2() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        LocalDateTime today = LocalDateTime.now();
+        Interview interviewNow = new Interview(TypicalApplicants.ALICE, "SWE", today, today);
+        interviewList.add(interviewNow);
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(interviewNow);
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewsToday3() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        LocalDateTime today = LocalDateTime.now();
+        int todayDay = today.getDayOfMonth();
+        int todayMonth = today.getMonthValue();
+        int todayYear = today.getYear();
+        Interview interviewNow = new Interview(TypicalApplicants.ALICE,
+                "SWE",
+                LocalDateTime.of(todayYear, todayMonth, todayDay, 9, 11),
+                LocalDateTime.of(todayYear, todayMonth, todayDay, 11, 11)
+                );
+        interviewList.add(interviewNow);
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(interviewNow);
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewsToday4() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        LocalDateTime today = LocalDateTime.now();
+        int todayDay = today.getDayOfMonth();
+        int todayMonth = today.getMonthValue();
+        int todayYear = today.getYear();
+        Interview interviewNow = new Interview(TypicalApplicants.ALICE,
+                "SWE",
+                LocalDateTime.of(todayYear, todayMonth, todayDay + 1, 9, 11),
+                LocalDateTime.of(todayYear, todayMonth, todayDay + 1, 11, 11)
+        );
+        interviewList.add(interviewNow);
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewsToday5() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        LocalDateTime today = LocalDateTime.now();
+        int todayDay = today.getDayOfMonth();
+        int todayMonth = today.getMonthValue();
+        int todayYear = today.getYear();
+        Interview interviewNow = new Interview(TypicalApplicants.ALICE,
+                "SWE",
+                LocalDateTime.of(todayYear, todayMonth + 1, todayDay, 9, 11),
+                LocalDateTime.of(todayYear, todayMonth + 1, todayDay, 11, 11)
+        );
+        interviewList.add(interviewNow);
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewsToday6() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        LocalDateTime today = LocalDateTime.now();
+        int todayDay = today.getDayOfMonth();
+        int todayMonth = today.getMonthValue();
+        int todayYear = today.getYear();
+        Interview interviewNow = new Interview(TypicalApplicants.ALICE,
+                "SWE",
+                LocalDateTime.of(todayYear + 1, todayMonth, todayDay, 9, 11),
+                LocalDateTime.of(todayYear + 1, todayMonth, todayDay, 11, 11)
+        );
+        interviewList.add(interviewNow);
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListInterviewsToday7() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        LocalDateTime today = LocalDateTime.now();
+        int todayDay = today.getDayOfMonth();
+        int todayMonth = today.getMonthValue();
+        int todayYear = today.getYear();
+        Interview interviewNow = new Interview(TypicalApplicants.ALICE,
+                "SWE",
+                LocalDateTime.of(todayYear, todayMonth, todayDay - 1, 9, 11),
+                LocalDateTime.of(todayYear, todayMonth, todayDay - 1, 11, 11)
+        );
+        interviewList.add(interviewNow);
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -547,4 +547,21 @@ class TimeParserTest {
         List<Interview> actual = TimeParser.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
+
+    /*
+     * Tests for the method which sorts the interviews in chronological order
+     */
+    @Test
+    void testSortInterviews() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        List<Interview> expected = new ArrayList<>();
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW);
+        expected.add(TypicalInterviews.STANDARD_INTERVIEW_2);
+        List<Interview> actual = TimeParser.sortInterviewsInChronologicalAscendingOrder(uniqueInterviewList);
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
- Add method that will take in the list of interviews that the user has,
and returns a List of Interview objects whose start date fall's on today's date

- Add tests for the `listInterviewsToday` method

- Add tests for the `listInterviewClashes` method

- closes #70 

- Added method to sort all the interviews that the user has so
far in ascending chronological order

- The method will sort based on start time of the interviews

- Will not modify the orginal list; will only return the sorted interview list
in a List<Interview>

- Add tests for the `sortInterviewsInChronologicalAscendingOrder` method

- closes #74 