### PR TITLE
Add find pockets of time method

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -138,7 +138,6 @@ public class TimeParser {
                 res.add(currentInterview);
             }
         }
-        System.out.println(res);
         return res;
     }
 

--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import seedu.address.model.interview.Interview;
@@ -136,6 +137,131 @@ public class TimeParser {
                     && currentInterviewStartTime.isBefore(endTime);
             if (completelyInside || completelyOutside || endInside || startInside) {
                 res.add(currentInterview);
+            }
+        }
+        return res;
+    }
+
+    /**
+     * Compiles a list of free times that the user has. Each element is a 2-element list where the
+     * first element is the start of the free time block, and the second element is the end of the
+     * free time block. Only places interviews that are within a 9-5 workday. Assumes that the given
+     * interview list has no clashes. Also assumes that the start time of any scheduled interviews are less
+     * than or equals to their corresponding end time.
+     *
+     * @author Tan Kerway
+     * @param day the day that the user inputs
+     * @param interviewList the list of interviews that the user has
+     * @return a list of free time blocks that the user has on a given day
+     */
+    public static List<List<LocalDateTime>> listPocketsOfTimeOnGivenDay(
+            LocalDateTime day,
+            UniqueInterviewList interviewList) {
+        // filter the interviews that fall on the given day, and sort in ascending
+        // chronological order
+        List<Interview> interviewsOnGivenDay =
+                listInterviewsOnGivenDay(day, interviewList);
+        UniqueInterviewList temp = new UniqueInterviewList();
+        temp.setInterviews(interviewsOnGivenDay);
+        List<Interview> interviewsOnGivenDaySorted = sortInterviewsInChronologicalAscendingOrder(temp);
+        List<List<LocalDateTime>> res = new ArrayList<>();
+        LocalDateTime startOfWorkDay = LocalDateTime.of(
+                day.getYear(),
+                day.getMonthValue(),
+                day.getDayOfMonth(),
+                9,
+                0);
+        LocalDateTime endOfWorkDay = LocalDateTime.of(
+                day.getYear(),
+                day.getMonthValue(),
+                day.getDayOfMonth(),
+                17,
+                0);
+        // track the previous end time of the interview
+        LocalDateTime prevEnd = startOfWorkDay.plusDays(0);
+
+        // find free time in 24h window
+        for (Interview interview : interviewsOnGivenDaySorted) {
+            // get the start time and end time
+            LocalDateTime currentInterviewStartTime = interview.getInterviewStartTime();
+            LocalDateTime currentInterviewEndTime = interview.getInterviewEndTime();
+            // case 1: the workday is completely overlapped by the interview
+            if (currentInterviewStartTime.isBefore(startOfWorkDay)
+                && currentInterviewEndTime.isAfter(endOfWorkDay)) {
+                prevEnd = currentInterviewEndTime.plusDays(0);
+                break;
+            }
+            // case 2: the workday is outside and before the workday
+            if (currentInterviewEndTime.isBefore(startOfWorkDay)) {
+                continue;
+            }
+            // case 3: the workday is outside and after the workday
+            if (currentInterviewStartTime.isAfter(endOfWorkDay)) {
+                break;
+            }
+            // case 4: the interview's start point is before the start of workday
+            // and the interview's end point is after the start of the workday
+            if (currentInterviewStartTime.isBefore(startOfWorkDay)
+                && currentInterviewEndTime.isAfter(startOfWorkDay)) {
+                prevEnd = currentInterviewEndTime.plusDays(0);
+                continue;
+            }
+            // get the current block of free time by taking the end of the last interval
+            // and the start of the current interval
+            List<LocalDateTime> currentFreeTime = new ArrayList<>();
+            currentFreeTime.add(prevEnd);
+            currentFreeTime.add(currentInterviewStartTime);
+            res.add(currentFreeTime);
+            prevEnd = currentInterviewEndTime;
+        }
+
+        // add stray free time, if any
+        if (prevEnd.isBefore(endOfWorkDay)) {
+            List<LocalDateTime> strayFreeTime = new ArrayList<>();
+            strayFreeTime.add(prevEnd);
+            strayFreeTime.add(endOfWorkDay);
+            res.add(strayFreeTime);
+        }
+        return res;
+    }
+
+
+    /**
+     * Sorts the list of interviews in ascending chronological order.
+     *
+     * @author Tan Kerway
+     *
+     */
+    public static List<Interview> sortInterviewsInChronologicalAscendingOrder(UniqueInterviewList interviews) {
+        List<Interview> res = new ArrayList<>();
+        for (Interview interview : interviews) {
+            res.add(interview);
+        }
+        res.sort(Comparator.comparing(Interview::getInterviewStartTime));
+        return res;
+    }
+
+    /**
+     * Compiles a list of interviews that the user has on a given day
+     *
+     * @author Tan Kerway
+     *
+     */
+    public static List<Interview> listInterviewsOnGivenDay(LocalDateTime day, UniqueInterviewList interviews) {
+        int todayDay = day.getDayOfMonth();
+        int todayMonth = day.getMonthValue();
+        int todayYear = day.getYear();
+        List<Interview> res = new ArrayList<>();
+        // loop over all the interviews, and add those that have today as the start time
+        for (Interview interview : interviews) {
+            LocalDateTime currentInterviewStartTime = interview.getInterviewStartTime();
+            int currentInterviewDay = currentInterviewStartTime.getDayOfMonth();
+            int currentInterviewMonth = currentInterviewStartTime.getMonthValue();
+            int currentInterviewYear = currentInterviewStartTime.getYear();
+            if (currentInterviewDay == todayDay
+                    && currentInterviewMonth == todayMonth
+                    && currentInterviewYear == todayYear) {
+                res.add(interview); // add the current interview if its start date is today
             }
         }
         return res;

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,12 +21,14 @@ import seedu.address.testutil.TypicalInterviews;
 class TimeParserTest {
     private static final LocalDateTime DEFAULT_DATE =
             LocalDateTime.of(1970, 1, 1, 0, 0);
+    private final Logger logger = Logger.getLogger("TimeParserTestLogger");
 
     /*
      * Tests for the timeParser class
      */
     @Test
     void testTimeParserDefaultDate() {
+        logger.log(Level.INFO, "Tests that field does not disappear");
         assertEquals(DEFAULT_DATE, TimeParser.DEFAULT_DATE);
     }
 
@@ -130,12 +134,12 @@ class TimeParserTest {
 
     @Test
     void testParseDateYearMonthDayTime5SuccessfulParse() throws ParseException {
-        System.out.println(TimeParser.parseDate("15 Dec 2023 1.30pm"));
+        TimeParser.parseDate("15 Dec 2023 1.30pm");
     }
 
     @Test
     void testParseDateYearMonthDayTime6SuccessfulParse() throws ParseException {
-        System.out.println(TimeParser.parseDate("31 mar 2099 1453"));
+        TimeParser.parseDate("31 mar 2099 1453");
     }
 
     @Test
@@ -308,7 +312,6 @@ class TimeParserTest {
         element.add(LocalDateTime.of(2024, 12, 21, 17, 0));
         expected.add(element);
         List<List<LocalDateTime>> actual = TimeParser.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
-        System.out.println(actual);
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -5,10 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.interview.Interview;
+import seedu.address.model.interview.UniqueInterviewList;
+import seedu.address.testutil.TypicalApplicants;
+import seedu.address.testutil.TypicalInterviews;
 
 class TimeParserTest {
     private static final LocalDateTime DEFAULT_DATE =
@@ -283,5 +289,48 @@ class TimeParserTest {
             hasError = true;
         }
         assertTrue(hasError);
+    }
+
+    /*
+     * Tests for the listPocketsOfTimeOnGivenDay method
+     */
+    @Test
+    void testListPocketsOfFreeTime() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime day = LocalDateTime.of(2024, 12, 21, 0, 0);
+        List<List<LocalDateTime>> expected = new ArrayList<>();
+        List<LocalDateTime> element = new ArrayList<>();
+        element.add(LocalDateTime.of(2024, 12, 21, 9, 0));
+        element.add(LocalDateTime.of(2024, 12, 21, 17, 0));
+        expected.add(element);
+        List<List<LocalDateTime>> actual = TimeParser.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
+        System.out.println(actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testListPocketsOfFreeTime2() {
+        List<Interview> interviewList = TypicalInterviews.getTypicalInterviews();
+        interviewList.add(new Interview(TypicalApplicants.HOON,
+                "SWE",
+                LocalDateTime.of(2024, 12, 21, 10, 0),
+                LocalDateTime.of(2024, 12, 21, 11, 0)
+                ));
+        UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
+        uniqueInterviewList.setInterviews(interviewList);
+        LocalDateTime day = LocalDateTime.of(2024, 12, 21, 0, 0);
+        List<List<LocalDateTime>> expected = new ArrayList<>();
+        List<LocalDateTime> element1 = new ArrayList<>();
+        element1.add(LocalDateTime.of(2024, 12, 21, 9, 0));
+        element1.add(LocalDateTime.of(2024, 12, 21, 10, 0));
+        List<LocalDateTime> element2 = new ArrayList<>();
+        element2.add(LocalDateTime.of(2024, 12, 21, 11, 0));
+        element2.add(LocalDateTime.of(2024, 12, 21, 17, 0));
+        expected.add(element1);
+        expected.add(element2);
+        List<List<LocalDateTime>> actual = TimeParser.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
- the method returns the time blocks that are free of interviews within the workday (i.e. 9am to 5pm) of the given day.

- this method assumes that the interviews are non-clashing.

- this method assumes that the start time of interview is always less than or equals to (chronologically) of its corresponding end time.

- tests also added to cover this method.

- potentially still buggy/violates coding standard but will fix these issues iteratively.

- closes #72 