### PR TITLE
Convert timemodel to time class

### DIFF
--- a/src/main/java/seedu/address/model/Time.java
+++ b/src/main/java/seedu/address/model/Time.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -14,7 +15,28 @@ import seedu.address.model.interview.UniqueInterviewList;
  *
  * @author Tan Kerway
  */
-public class TimeModel {
+public class Time implements Comparable<Time> {
+    /*
+     * Class-level Time constants
+     */
+    private static final LocalTime WORK_START = LocalTime.of(9, 0);
+    private static final LocalTime WORK_END = LocalTime.of(17, 0);
+
+    /*
+     * Instance-level Time fields
+     */
+    private final LocalDateTime time;
+
+    /**
+     * Constructs a Time instance based on the input LocalDateTime.
+     *
+     * @author Tan Kerway
+     * @param time the LocalDateTime to represent with the Time instance
+     */
+    public Time(LocalDateTime time) {
+        this.time = time;
+    }
+
     /**
      * Returns the interviews which clash with the current interview
      *
@@ -206,5 +228,117 @@ public class TimeModel {
             }
         }
         return res;
+    }
+
+    /**
+     * Compares the other given time to this instance.
+     *
+     * @author Tan Kerway
+     * @param otherTime the other time to compare with this instance
+     */
+    @Override
+    public int compareTo(Time otherTime) {
+        return this.time.compareTo(otherTime.time);
+    }
+
+    /**
+     * Checks whether this instance is before the given time.
+     *
+     * @author Tan Kerway
+     * @param otherTime the other time to compare to
+     * @return true if this instance is before the otherTime, false otherwise
+     */
+    public boolean isBefore(Time otherTime) {
+        return this.time.isBefore(otherTime.time);
+    }
+
+    /**
+     * Checks whether this instance is after the given time.
+     *
+     * @author Tan Kerway
+     * @param otherTime the other time to compare to
+     * @return true if this instance is after the otherTime, false otherwise
+     */
+    public boolean isAfter(Time otherTime) {
+        return this.time.isBefore(otherTime.time);
+    }
+
+    /**
+     * Returns true if startTime and endTime are within working hours,
+     * which is defined to be between 0900 and 1700.
+     *
+     * @author Tan Jing Jie, Tan Kerway
+     * @return true if within the working hours, false otherwise
+     */
+    public boolean isWithinWorkingHours() {
+        LocalTime timeFields = this.time.toLocalTime();
+        return (timeFields.isAfter(WORK_START) || timeFields.equals(WORK_START))
+                && (timeFields.isBefore(WORK_END) || timeFields.equals(WORK_END));
+    }
+
+    /**
+     * Returns the time associated with the current Time instance.
+     *
+     * @author Tan Kerway
+     * @return a LocalTime object instance containing the time of the current instance
+     */
+    public LocalTime getTime() {
+        return this.time.toLocalTime();
+    }
+
+    /**
+     * Returns the date and time associated with the current Time instance.
+     *
+     * @author Tan Kerway
+     * @return a copy of the LocalTime object instance containing the date and time of the current instance
+     */
+    public LocalDateTime getDateAndTime() {
+        return this.time.plusDays(0);
+    }
+
+    /**
+     * Checks if the given Object instance is equals to
+     * this Time instance.
+     *
+     * @author Tan Kerway
+     * @param otherObject the other object to compare to
+     * @return true if this Time instance is equals, and false otherwise
+     */
+    @Override
+    public boolean equals(Object otherObject) {
+        if (this == otherObject) {
+            return true;
+        }
+        // guard clause: the given object does not have a run time type of Time
+        if (!(otherObject instanceof Time)) {
+            return false;
+        }
+        // else, we know the given object is an instance of time,
+        // hence, it is safe to cast to Time
+        return this.time.equals(((Time) otherObject).time);
+    }
+
+    /**
+     * Returns the hashcode of the current Time instance. Effectively returns
+     * the hashcode of the time field.
+     *
+     * @author Tan Kerway
+     * @return the hashcode of the current Time instance
+     */
+    @Override
+    public int hashCode() {
+        return this.time.hashCode();
+    }
+
+    /**
+     * Returns the String representation of the Time instance. Effectively returns the String
+     * representation of the String since the Time class is merely a wrapper class for Time.
+     *
+     * @author Tan Kerway
+     * @return the String representation of the Time object
+     */
+    @Override
+    public String toString() {
+        return this.time.toString();
     }
 }

--- a/src/main/java/seedu/address/model/Time.java
+++ b/src/main/java/seedu/address/model/Time.java
@@ -1,5 +1,6 @@
 package seedu.address.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -284,6 +285,16 @@ public class Time implements Comparable<Time> {
      */
     public LocalTime getTime() {
         return this.time.toLocalTime();
+    }
+
+    /**
+     * Returns the date associated with the current Time instance.
+     *
+     * @author Tan Kerway
+     * @return a LocalDate object instance containing the date of the current instance
+     */
+    public LocalDate getDate() {
+        return this.time.toLocalDate();
     }
 
     /**

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -149,7 +149,7 @@ public class Interview {
         return startTime.isBefore(endTime)
                 && startTime.isWithinWorkingHours()
                 && endTime.isWithinWorkingHours()
-                && startTime.getTime().equals(endTime.getTime());
+                && startTime.getDate().equals(endTime.getDate());
     }
 
     public Applicant getInterviewApplicant() {

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -3,23 +3,21 @@ package seedu.address.model.interview;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import seedu.address.logic.parser.TimeParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Time;
 import seedu.address.model.applicant.Applicant;
 
 /**
  * Represents an Interview in the address book.
  */
 public class Interview {
-    private static final LocalTime WORK_START = LocalTime.of(9, 0);
-    private static final LocalTime WORK_END = LocalTime.of(17, 0);
     private final Applicant applicant;
     private final String jobRole;
     private final Rating rating;
-    private final LocalDateTime startTime;
-    private final LocalDateTime endTime;
+    private final Time startTime;
+    private final Time endTime;
     private final boolean isDone;
 
     /**
@@ -31,8 +29,8 @@ public class Interview {
         this.applicant = app;
         this.jobRole = role;
         this.rating = new Rating("0.0");
-        this.startTime = TimeParser.parseDate(startTimeString);
-        this.endTime = TimeParser.parseDate(endTimeString);
+        this.startTime = new Time(TimeParser.parseDate(startTimeString));
+        this.endTime = new Time(TimeParser.parseDate(endTimeString));
         this.isDone = false;
     }
 
@@ -53,8 +51,8 @@ public class Interview {
         requireAllNonNull(app, role, startTimeString, endTimeString);
         this.applicant = app;
         this.jobRole = role;
-        this.startTime = TimeParser.parseDate(startTimeString);
-        this.endTime = TimeParser.parseDate(endTimeString);
+        this.startTime = new Time(TimeParser.parseDate(startTimeString));
+        this.endTime = new Time(TimeParser.parseDate(endTimeString));
         this.rating = rating;
         this.isDone = isDone;
     }
@@ -74,8 +72,8 @@ public class Interview {
         requireAllNonNull(app, role, startTimeString, endTimeString);
         this.applicant = app;
         this.jobRole = role;
-        this.startTime = TimeParser.parseDate(startTimeString);
-        this.endTime = TimeParser.parseDate(endTimeString);
+        this.startTime = new Time(TimeParser.parseDate(startTimeString));
+        this.endTime = new Time(TimeParser.parseDate(endTimeString));
         this.rating = new Rating("0.0");
         this.isDone = isDone;
     }
@@ -88,8 +86,8 @@ public class Interview {
         requireAllNonNull(app, role, startTime, endTime, isDone);
         this.applicant = app;
         this.jobRole = role;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.startTime = new Time(startTime);
+        this.endTime = new Time(endTime);
         this.rating = new Rating("0.0");
         this.isDone = isDone;
     }
@@ -102,8 +100,8 @@ public class Interview {
         requireAllNonNull(app, role, startTime, endTime, rate, isDone);
         this.applicant = app;
         this.jobRole = role;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.startTime = new Time(startTime);
+        this.endTime = new Time(endTime);
         this.rating = rate;
         this.isDone = isDone;
     }
@@ -122,8 +120,8 @@ public class Interview {
         requireAllNonNull(app, role, startTime, endTime);
         applicant = app;
         jobRole = role;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.startTime = new Time(startTime);
+        this.endTime = new Time(endTime);
         this.rating = new Rating("0.0");
         this.isDone = false;
     }
@@ -149,19 +147,9 @@ public class Interview {
      */
     public boolean isValid() {
         return startTime.isBefore(endTime)
-                && isWithinWorkingHours(startTime)
-                && isWithinWorkingHours(endTime)
-                && startTime.toLocalDate().isEqual(endTime.toLocalDate());
-    }
-
-    /**
-     * Returns true if startTime and endTime are within working hours,
-     * which is defined to be between 0900 and 1700.
-     */
-    public boolean isWithinWorkingHours(LocalDateTime dateTime) {
-        LocalTime time = dateTime.toLocalTime();
-        return (time.isAfter(WORK_START) || time.equals(WORK_START))
-                && (time.isBefore(WORK_END) || time.equals(WORK_END));
+                && startTime.isWithinWorkingHours()
+                && endTime.isWithinWorkingHours()
+                && startTime.getTime().equals(endTime.getTime());
     }
 
     public Applicant getInterviewApplicant() {
@@ -173,19 +161,19 @@ public class Interview {
     }
 
     public String getInterviewStartTimeAsString() {
-        return TimeParser.formatDate(startTime);
+        return TimeParser.formatDate(startTime.getDateAndTime());
     }
 
     public LocalDateTime getInterviewStartTime() {
-        return startTime.plusDays(0);
+        return startTime.getDateAndTime();
     }
 
     public String getInterviewEndTimeAsString() {
-        return TimeParser.formatDate(endTime);
+        return TimeParser.formatDate(endTime.getDateAndTime());
     }
 
     public LocalDateTime getInterviewEndTime() {
-        return endTime.plusDays(0);
+        return endTime.getDateAndTime();
     }
 
     public Rating getRating() {

--- a/src/main/java/seedu/address/model/interview/Rating.java
+++ b/src/main/java/seedu/address/model/interview/Rating.java
@@ -58,5 +58,4 @@ public class Rating implements Comparable<Rating> {
     public int hashCode() {
         return rating.hashCode();
     }
-
 }

--- a/src/test/java/seedu/address/model/TimeTest.java
+++ b/src/test/java/seedu/address/model/TimeTest.java
@@ -13,7 +13,7 @@ import seedu.address.model.interview.UniqueInterviewList;
 import seedu.address.testutil.TypicalApplicants;
 import seedu.address.testutil.TypicalInterviews;
 
-public class TimeModelTest {
+public class TimeTest {
     /*
      * Tests for the listInterviewClashes class
      */
@@ -26,7 +26,7 @@ public class TimeModelTest {
         LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 20, 30);
         List<Interview> expected = new ArrayList<>();
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -38,7 +38,7 @@ public class TimeModelTest {
         LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 22, 0);
         List<Interview> expected = new ArrayList<>();
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -51,7 +51,7 @@ public class TimeModelTest {
         LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 19, 1);
         List<Interview> expected = new ArrayList<>();
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -64,7 +64,7 @@ public class TimeModelTest {
         LocalDateTime endTime = LocalDateTime.of(2024, 12, 21, 22, 0);
         List<Interview> expected = new ArrayList<>();
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -78,7 +78,7 @@ public class TimeModelTest {
         List<Interview> expected = new ArrayList<>();
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -93,7 +93,7 @@ public class TimeModelTest {
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -108,7 +108,7 @@ public class TimeModelTest {
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -124,7 +124,7 @@ public class TimeModelTest {
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_2);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_3);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -136,7 +136,7 @@ public class TimeModelTest {
         LocalDateTime startTime = LocalDateTime.of(2023, 5, 12, 9, 0);
         LocalDateTime endTime = LocalDateTime.of(2023, 12, 21, 22, 0);
         List<Interview> expected = new ArrayList<>();
-        List<Interview> actual = TimeModel.listInterviewClashes(startTime, endTime, uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewClashes(startTime, endTime, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -149,7 +149,7 @@ public class TimeModelTest {
         UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -163,7 +163,7 @@ public class TimeModelTest {
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
         expected.add(interviewNow);
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -184,7 +184,7 @@ public class TimeModelTest {
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
         expected.add(interviewNow);
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -204,7 +204,7 @@ public class TimeModelTest {
         UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -224,7 +224,7 @@ public class TimeModelTest {
         UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -244,7 +244,7 @@ public class TimeModelTest {
         UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -264,7 +264,7 @@ public class TimeModelTest {
         UniqueInterviewList uniqueInterviewList = new UniqueInterviewList();
         uniqueInterviewList.setInterviews(interviewList);
         List<Interview> expected = new ArrayList<>();
-        List<Interview> actual = TimeModel.listInterviewsToday(uniqueInterviewList);
+        List<Interview> actual = Time.listInterviewsToday(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -282,7 +282,7 @@ public class TimeModelTest {
         element.add(LocalDateTime.of(2024, 12, 21, 9, 0));
         element.add(LocalDateTime.of(2024, 12, 21, 17, 0));
         expected.add(element);
-        List<List<LocalDateTime>> actual = TimeModel.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
+        List<List<LocalDateTime>> actual = Time.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -306,7 +306,7 @@ public class TimeModelTest {
         element2.add(LocalDateTime.of(2024, 12, 21, 17, 0));
         expected.add(element1);
         expected.add(element2);
-        List<List<LocalDateTime>> actual = TimeModel.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
+        List<List<LocalDateTime>> actual = Time.listPocketsOfTimeOnGivenDay(day, uniqueInterviewList);
         assertEquals(expected, actual);
     }
 
@@ -323,7 +323,7 @@ public class TimeModelTest {
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_4);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW);
         expected.add(TypicalInterviews.STANDARD_INTERVIEW_2);
-        List<Interview> actual = TimeModel.sortInterviewsInChronologicalAscendingOrder(uniqueInterviewList);
+        List<Interview> actual = Time.sortInterviewsInChronologicalAscendingOrder(uniqueInterviewList);
         assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
- This PR changes the name of TimeModel into Time

- Renamed so that it is consistent with the other objects 
in the application (e.g. Interview, Rating, Applicant, etc)

- Refactored time-related methods for better separation of concerns

- closes #113 